### PR TITLE
fix: replace Bitnami images with open Soldevelo equivalents

### DIFF
--- a/docker/docker-compose/cloud/standalone/signal-docker-compose-test.yml
+++ b/docker/docker-compose/cloud/standalone/signal-docker-compose-test.yml
@@ -222,7 +222,7 @@ services:
         ipv4_address: 172.11.0.23
 
   kafka:
-    image: bitnami/kafka:3.7
+    image: soldevelo/kafka:3.7
     container_name: kafka
     ports:
       - "9092:9092"

--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -353,7 +353,7 @@ services:
         ipv4_address: 172.11.0.23
 
   kafka:
-    image: bitnami/kafka:3.7
+    image: soldevelo/kafka:3.7
     container_name: kafka
     restart: no	
     ports:


### PR DESCRIPTION
## Fix: replace restricted Bitnami images

Since **August 28, 2025**, Bitnami distributes most container images only through paid VMware Tanzu subscriptions. Pulling them without a valid subscription may fail silently or return stale image layers, which is a supply-chain reliability concern.

This PR replaces every affected reference with the corresponding image from [SolDevelo/containers](https://github.com/SolDevelo/containers) - a community fork of `bitnami/containers` that publishes identical, freely accessible images to Docker Hub under the `soldevelo/` namespace.

No configuration changes beyond the image tag itself are required.

## Replaced references

- `bitnami/kafka:3.7` → [`soldevelo/kafka:3.7`](https://hub.docker.com/r/soldevelo/kafka)